### PR TITLE
Fixed min compatibility

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -34,7 +34,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2020.1",
+	"addon_minimumNVDAVersion": "2020.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is None, denoting stable releases,

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 * Author: Oleksandr Gryshchenko
 * Version: 1.0
-* NVDA compatibility: 2020.1 and beyond
+* NVDA compatibility: 2020.3 and beyond
 * Download [stable version][1]
 
 Find and fix input gestures conflicts in NVDA and add-ons. The general term "input gestures" includes keyboard commands, commands entered from Braille keyboards and gestures of touch screens.


### PR DESCRIPTION
Hi @grisov 

PR #6 aimed to fix #5 and actually fixed the issue for NVDA 2019.3.
Unfortunately the same issue occurs for NVDA 2020.1, since `gui.inputGestures.py` has been introduced with NVDA 2020.3.

This PR updates again the minimum supported NVDA version to 2020.3.

Tests on NVDA 2020.3 are OK.

Cc @tech10 
